### PR TITLE
Allow returning *only* SNP ids from SNPRateFreq

### DIFF
--- a/R/AllUtilities.R
+++ b/R/AllUtilities.R
@@ -177,11 +177,13 @@ snpgdsClose <- function(gdsobj)
 #
 
 snpgdsSNPRateFreq <- function(gdsobj, sample.id=NULL, snp.id=NULL,
-    with.id=FALSE)
+    with.id=FALSE, with.snp.id=FALSE, with.sample.id=FALSE)
 {
     # check
     ws <- .InitFile(gdsobj, sample.id=sample.id, snp.id=snp.id)
     stopifnot(is.logical(with.id))
+    stopifnot(is.logical(with.snp.id))
+    stopifnot(is.logical(with.sample.id))
 
     # call allele freq. and missing rates
     rv <- .Call(gnrSNPRateFreq)
@@ -189,10 +191,17 @@ snpgdsSNPRateFreq <- function(gdsobj, sample.id=NULL, snp.id=NULL,
 
     if (with.id)
     {
+        with.snp.id <- TRUE
+        with.sample.id <- TRUE
+    }
+    if (with.sample.id)
+    {
         rv$sample.id <- read.gdsn(index.gdsn(gdsobj, "sample.id"))
         if (!is.null(ws$samp.flag))
             rv$sample.id <- rv$sample.id[ws$samp.flag]
-
+    }
+    if (with.snp.id)
+    {
         rv$snp.id <- read.gdsn(index.gdsn(gdsobj, "snp.id"))
         if (!is.null(ws$snp.flag))
             rv$snp.id <- rv$snp.id[ws$snp.flag]


### PR DESCRIPTION
This patch allows one to receive only the SNP ids when calling `snpgdsSNPRateFreq`. This is primarily useful because then the return value can easily be converted into a data frame, as all members of the list will have the same length.